### PR TITLE
[feat]#13:좌표 근처 주차장 목록 조회

### DIFF
--- a/src/main/java/com/team4/ttukttak_parking/controller/PkltController.java
+++ b/src/main/java/com/team4/ttukttak_parking/controller/PkltController.java
@@ -2,18 +2,21 @@ package com.team4.ttukttak_parking.controller;
 
 import com.team4.ttukttak_parking.domain.pklt.dto.PkltInfoResponse;
 import com.team4.ttukttak_parking.domain.pklt.dto.PkltResponse;
+import com.team4.ttukttak_parking.domain.pklt.dto.PkltSimpleDto;
 import com.team4.ttukttak_parking.domain.pklt.service.PkltService;
 import com.team4.ttukttak_parking.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +34,17 @@ public class PkltController {
     @GetMapping("/{pkltId}")
     public ResponseEntity<ApiResponse<PkltResponse>> getParkingLots(@PathVariable Long pkltId) {
         return ResponseEntity.ok().body(ApiResponse.createSuccess(pkltService.getParkingLots(pkltId)));
+    }
+
+
+    @Operation(summary = "좌표 근처 주차장 정보 조회 API", description = "좌표 근처 주차장 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+    })
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<PkltSimpleDto>>> getParkingLots(@Parameter(description = "위도") @RequestParam(value = "lat") BigDecimal lat, @Parameter(description = "경도") @RequestParam(value ="lng") BigDecimal lng ){
+        return ResponseEntity.ok().body(ApiResponse.createSuccess(pkltService.getCloseParkingLots(lat,lng)));
+
     }
 
     @GetMapping("/{pkltId}/info")

--- a/src/main/java/com/team4/ttukttak_parking/domain/pklt/dto/PkltSimpleDto.java
+++ b/src/main/java/com/team4/ttukttak_parking/domain/pklt/dto/PkltSimpleDto.java
@@ -1,0 +1,21 @@
+package com.team4.ttukttak_parking.domain.pklt.dto;
+
+import com.team4.ttukttak_parking.domain.pklt.entity.Pklt;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class PkltSimpleDto {
+    Long id;
+    BigDecimal latitude;
+    BigDecimal longitude;
+
+
+    public static PkltSimpleDto from(Pklt pklt){
+        return new PkltSimpleDto(pklt.getPkltId(),pklt.getLat(),pklt.getLot());
+    }
+}

--- a/src/main/java/com/team4/ttukttak_parking/domain/pklt/service/PkltService.java
+++ b/src/main/java/com/team4/ttukttak_parking/domain/pklt/service/PkltService.java
@@ -2,15 +2,22 @@ package com.team4.ttukttak_parking.domain.pklt.service;
 
 import com.team4.ttukttak_parking.domain.pklt.dto.PkltInfoResponse;
 import com.team4.ttukttak_parking.domain.pklt.dto.PkltResponse;
+import com.team4.ttukttak_parking.domain.pklt.dto.PkltSimpleDto;
 import com.team4.ttukttak_parking.domain.pklt.entity.Pklt;
 import com.team4.ttukttak_parking.domain.pklt.entity.PkltInfo;
 import com.team4.ttukttak_parking.domain.pklt.repository.PkltInfoRepository;
 import com.team4.ttukttak_parking.domain.pklt.repository.PkltRepository;
 import com.team4.ttukttak_parking.global.exception.ErrorCode;
 import com.team4.ttukttak_parking.global.exception.NotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -54,4 +61,17 @@ public class PkltService {
                 .dayMaxCrg(pkltInfo.getDayMaxCrg())
                 .build();
     }
+
+    public List<PkltSimpleDto> getCloseParkingLots(BigDecimal lat, BigDecimal lng){
+        double KM = 3.0;
+        double lngDifference = KM /111/(Math.cos(lat.doubleValue()));
+
+        Predicate<Pklt> latFilter = pklt ->  pklt.getLat().doubleValue() > lat.doubleValue() -  (KM / 111) && lat.doubleValue() + (KM / 111) > pklt.getLat().doubleValue();
+        Predicate<Pklt> lngFilter = pklt -> pklt.getLot().doubleValue() > lng.doubleValue() - lngDifference && pklt.getLot().doubleValue() < lng.doubleValue() +lngDifference;
+
+        return pkltRepository.findAll().stream().filter(latFilter.and(lngFilter)).map(PkltSimpleDto::from).collect(Collectors.toList());
+    }
+
+
+
 }


### PR DESCRIPTION
📌 과제 설명 
좌표 근처 주차장 목록 조회

👩‍💻 요구 사항과 구현 내용

특정 좌표 반경 N km 근처 주차장 목록 조회.
현재 코드 상에는 5km로 상수 변수로  작성되어 있음.   

✅ 건의사항

위도와 경도를 bigDeciaml로 entity에 저장하면 연산에 많은 시간이 걸림. -> dobule 형으로 바꿔서 저장하는 것을 논의.
double형은 소숫점 15자리 정도까지 유효함을 보장함. 