### PR TITLE
[feat] 주차권 주문 구현

### DIFF
--- a/src/main/java/com/team4/ttukttak_parking/controller/OrderController.java
+++ b/src/main/java/com/team4/ttukttak_parking/controller/OrderController.java
@@ -1,0 +1,39 @@
+package com.team4.ttukttak_parking.controller;
+
+import com.team4.ttukttak_parking.domain.order.dto.OrderRequest;
+import com.team4.ttukttak_parking.domain.order.service.OrderService;
+import com.team4.ttukttak_parking.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+@Slf4j
+@Tag(name = "Order Tickets", description = "주차권 주문 관련 API")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    // 주차권 구매 요청
+    @Operation(summary = "주차권 주문 요청 API", description = "주차권 구매를 요청합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+    })
+    @PostMapping("/tickets")
+    public ResponseEntity<ApiResponse<Object>> createOrder(@RequestBody OrderRequest.Order orderRequest, @AuthenticationPrincipal User user) {
+        orderService.createOrder(orderRequest, user.getUsername());
+        return ResponseEntity.ok()
+            .body(ApiResponse.createSuccessWithNoData());
+    }
+}

--- a/src/main/java/com/team4/ttukttak_parking/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/team4/ttukttak_parking/domain/order/dto/OrderRequest.java
@@ -2,4 +2,10 @@ package com.team4.ttukttak_parking.domain.order.dto;
 
 public record OrderRequest() {
 
+    public record Order(
+        Long ticketId,
+        String carNumber
+    ) {
+
+    }
 }

--- a/src/main/java/com/team4/ttukttak_parking/domain/order/entity/Order.java
+++ b/src/main/java/com/team4/ttukttak_parking/domain/order/entity/Order.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -28,6 +29,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@Builder
 @Table(name = "orders")
 public class Order {
 
@@ -55,5 +57,12 @@ public class Order {
     @CreatedDate
     private LocalDateTime createdAt;
 
-
+    public static Order to(String carNum, Ticket ticket, Member member) {
+        return Order.builder()
+            .carNum(carNum)
+            .ticket(ticket)
+            .member(member)
+            .status(ParkingStatus.WAITING)
+            .build();
+    }
 }

--- a/src/main/java/com/team4/ttukttak_parking/domain/order/service/OrderService.java
+++ b/src/main/java/com/team4/ttukttak_parking/domain/order/service/OrderService.java
@@ -1,13 +1,58 @@
 package com.team4.ttukttak_parking.domain.order.service;
 
+import com.team4.ttukttak_parking.domain.member.entity.Member;
+import com.team4.ttukttak_parking.domain.member.repository.MemberRepository;
+import com.team4.ttukttak_parking.domain.order.dto.OrderRequest;
+import com.team4.ttukttak_parking.domain.order.entity.Order;
 import com.team4.ttukttak_parking.domain.order.repository.OrderRepository;
+import com.team4.ttukttak_parking.domain.pkltstatus.entity.PkltStatus;
+import com.team4.ttukttak_parking.domain.pkltstatus.entity.enums.ParkingStatus;
+import com.team4.ttukttak_parking.domain.ticket.entity.Ticket;
+import com.team4.ttukttak_parking.domain.ticket.repository.TicketRepository;
+import com.team4.ttukttak_parking.global.exception.BadRequestException;
+import com.team4.ttukttak_parking.global.exception.ErrorCode;
+import com.team4.ttukttak_parking.global.exception.NotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderService {
 
+    private final TicketRepository ticketRepository;
+    private final MemberRepository memberRepository;
     private final OrderRepository orderRepository;
 
+    @Transactional
+    public void createOrder(OrderRequest.Order orderRequest, String email) {
+        // 회원 검색
+        final Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        // 해당 주차권 검색
+        final Ticket ticket = ticketRepository.findById(orderRequest.ticketId())
+            .orElseThrow(() -> new NotFoundException(ErrorCode.TICKET_NOT_FOUND));
+
+        // 현재 기준 주차장 잔여자리 존재 예외처리
+        PkltStatus pkltStatus = ticket.getPklt().getPkltStatus();
+        if (pkltStatus.getTpkct() - pkltStatus.getNowPrkVhclCnt() <= 0) {
+            throw new BadRequestException(ErrorCode.PKLT_FULL);
+        }
+
+        int total = ticket.getPrice(); // 현재는 할인 혜택 없음
+
+        // 주차권 주문 생성 (결제 대기 상태로 생성, 결제 성공시 주차중 상태로 변경)
+        orderRepository.save(Order.to(
+            orderRequest.carNumber(),
+            ticket,
+            member
+        ));
+
+        // 주차 현황 주차 차량수 추가
+        pkltStatus.updateNowPrkVhclCnt();
+    }
 }
+

--- a/src/main/java/com/team4/ttukttak_parking/domain/pklt/entity/Pklt.java
+++ b/src/main/java/com/team4/ttukttak_parking/domain/pklt/entity/Pklt.java
@@ -1,13 +1,22 @@
 package com.team4.ttukttak_parking.domain.pklt.entity;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.team4.ttukttak_parking.domain.pkltstatus.entity.PkltStatus;
+import com.team4.ttukttak_parking.domain.ticket.entity.Ticket;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,6 +37,13 @@ public class Pklt {
 
     private String pkltNm;
     private String addr;
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "pkltStatusId")
+    private PkltStatus pkltStatus;
+
+    @OneToMany(mappedBy = "pklt", cascade = CascadeType.ALL)
+    private List<Ticket> tickets = new ArrayList<>();
 
     @Column(precision = 16, scale = 10, nullable = false)
     private BigDecimal lat;

--- a/src/main/java/com/team4/ttukttak_parking/domain/pkltstatus/entity/PkltStatus.java
+++ b/src/main/java/com/team4/ttukttak_parking/domain/pkltstatus/entity/PkltStatus.java
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.team4.ttukttak_parking.domain.pklt.entity.Pklt;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -35,8 +33,7 @@ public class PkltStatus {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long pkltStatusId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "pklt_id", nullable = false)
+    @OneToOne(mappedBy = "pkltStatus")
     private Pklt pklt;
 
     private int tpkct;          // 총 주차 면
@@ -55,5 +52,9 @@ public class PkltStatus {
 
     public void fixStreetPklt() {
         this.tpkct += 1;
+    }
+
+    public void updateNowPrkVhclCnt() {
+        this.nowPrkVhclCnt += 1;
     }
 }

--- a/src/main/java/com/team4/ttukttak_parking/global/exception/ErrorCode.java
+++ b/src/main/java/com/team4/ttukttak_parking/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode { // 예외 발생시, body에 실어 날려줄 상태, co
     PKLT_ALREADY_PARKED(400, -4002, "이미 주차 중인 차량입니다."),
 
     //-5000: TICKET
+    TICKET_NOT_FOUND(404, -5000, "주차권을 찾을 수 없습니다."),
     TICKET_ALREADY_EXIST(400, -5001, "해당 주차권이 이미 존재합니다.");
 
     // 1. status = 날려줄 상태코드


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 
- 주차권 주문 요청시, 주문을 생성하고 주문처리

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 주차장 엔티티에 외래키를 두고, 주차 현황 테이블과 양방향 일대일 관계 구현
- 주차장 엔티티에 `@OneToMany`로 `ticketList`변수 추가
- Orders 엔티티 status에`PENDING_PAYMENT('결제 대기')`, `FAILED_PAYMENT('결제 실패')` 상태를 추가
- OrderRequest의 파라미터는 현재 ticketId, carNumber로 설정
- 주문 생성시 '결제 대기'상태로 생성
- Toss Payments 결제 실패시 '결제 실패'로 상태변경, 성공시 '주차중'상태로 변경 구현예정

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
